### PR TITLE
Support for arbitrary nested anonymous structs

### DIFF
--- a/structx/Cargo.toml
+++ b/structx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "structx"
-version = "0.1.9"
+version = "0.1.10"
 authors = ["oooutlk <oooutlk@outlook.com>"]
 edition = "2021"
 license = "MIT/Apache-2.0"
@@ -15,7 +15,7 @@ description = "Simulating anonymous struct and named arguments in Rust."
 inwelling = "0.5"
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "1.0", features = ["extra-traits","full","parsing","visit","visit-mut"] }
+syn = { version = "2.0", features = ["extra-traits","full","parsing","visit","visit-mut"] }
 
 [dependencies]
 structx_derive = { path = "../structx_derive", version = "^0.1.3" }

--- a/structx/build.rs
+++ b/structx/build.rs
@@ -18,16 +18,30 @@ use std::{
     path::PathBuf,
 };
 
-use syn::{
-    FnArg,
-    ItemFn,
-    Macro,
-    Member,
-    Pat,
-    PatMacro,
-    Type,
-    visit::{self, Visit},
-};
+use syn::{Error, Expr, FnArg, GenericArgument, ItemFn, Macro, Member, Meta, Pat, Path, PathArguments, PatStruct, ReturnType, Type, visit::{self, Visit}};
+use syn::parse::{Parse, ParseStream};
+use syn::spanned::Spanned;
+
+/*
+ * Introduced a new type which can be parsed with syn::parse2.
+ * This is necessary because syn version 2 doesn't implement Parse for Pat
+ */
+struct StructX {
+    pat: PatStruct
+}
+impl Parse for StructX {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let pat = Pat::parse_single(input)?;
+        if let Pat::Struct(pat) = pat {
+            Ok(StructX { pat })
+        } else {
+            Err(Error::new(
+                pat.span(),
+                "structx!()'s supported pattern matching is struct only."
+            ))
+        }
+    }
+}
 
 fn wrap_struct_name( struct_name: &str, input: TokenStream ) -> TokenStream {
     let mut ts = Ident::new( struct_name, Span::call_site() ).into_token_stream();
@@ -35,107 +49,236 @@ fn wrap_struct_name( struct_name: &str, input: TokenStream ) -> TokenStream {
     ts
 }
 
-fn join_fields( fields: impl Iterator<Item=(Ident, Option<Type>)> ) -> (String, Vec<Ident>, Vec<Option<Type>>) {
+fn join_fields( fields: impl Iterator<Item=Ident> ) -> (String, Vec<Ident>) {
     let mut fields = fields.collect::<Vec<_>>();
-    fields.sort_by_key( |field| field.0.clone() );
+    fields.sort_by_key( |field| field.clone() );
     fields
         .into_iter()
         .fold(
-            ("structx".to_owned(), Vec::new(), Vec::new() ),
-            |(mut struct_name, mut field_idents, mut field_types), (ident, ty)| {
+            ("structx".to_owned(), Vec::new()),
+            |(mut struct_name, mut field_idents), ident| {
                 let field_name = ident.to_string();
-                struct_name.push( '_' );
-                struct_name.push_str( &field_name.replace( "_", "__" ));
-                field_idents.push( ident.clone() );
-                field_types.push( ty );
-                (struct_name, field_idents, field_types)
+                struct_name.push('_');
+                struct_name.push_str(&field_name.replace( "_", "__" ));
+                field_idents.push(ident);
+                (struct_name, field_idents)
             }
         )
 }
 
-type StructMap = HashMap<String, (Vec<Ident>, Vec<Option<Type>>)>;
+type StructMap = HashMap<String, Vec<Ident>>;
 
 struct StructxCollector<'a>( &'a mut StructMap );
 
 impl<'a> Visit<'_> for StructxCollector<'a> {
-    fn visit_macro( &mut self, mac: &Macro ) {
-        visit::visit_macro( self, mac );
-
-        if mac.path.leading_colon.is_none() && mac.path.segments.len() == 1 {
-            let seg = mac.path.segments.first().unwrap();
-            if ( seg.ident == "structx" || seg.ident == "Structx" ) && seg.arguments.is_none() {
-                self.parse_structx( mac.tokens.clone().into() );
-            }
-        }
-    }
-
     fn visit_item_fn( &mut self, item_fn: &ItemFn ) {
         visit::visit_item_fn( self, item_fn );
 
         for attr in &item_fn.attrs {
-            if attr.path.leading_colon.is_none() && attr.path.segments.len() == 1 {
-                if attr.path.segments.first().unwrap().ident == "named_args" {
-                    let fn_args = item_fn.sig.inputs.iter();
-                    let mut idents = Vec::with_capacity( fn_args.len() );
-                    let mut types = Vec::with_capacity( fn_args.len() );
-                    for fn_arg in fn_args {
-                        match fn_arg {
-                            FnArg::Receiver(_) => (),
-                            FnArg::Typed( pat_type ) => {
-                                if let Pat::Ident( pat_ident ) = &*pat_type.pat {
-                                    idents.push( pat_ident.ident.clone() );
-                                    types .push( (*pat_type.ty).clone() );
-                                } else {
-                                    panic!("#[named_args] function's arguments should be either receiver or `id: Type`.");
-                                }
-                            },
+            if let Meta::Path(path) = &attr.meta {
+                if path.leading_colon.is_none() && path.segments.len() == 1 {
+                    if path.segments.first().unwrap().ident == "named_args" {
+                        let fn_args = item_fn.sig.inputs.iter();
+                        let mut idents = Vec::with_capacity( fn_args.len() );
+                        let mut types = Vec::with_capacity( fn_args.len() );
+                        for fn_arg in fn_args {
+                            match fn_arg {
+                                FnArg::Receiver(_) => (),
+                                FnArg::Typed( pat_type ) => {
+                                    if let Pat::Ident( pat_ident ) = &*pat_type.pat {
+                                        idents.push( pat_ident.ident.clone() );
+                                        types .push( (*pat_type.ty).clone() );
+                                    } else {
+                                        panic!("#[named_args] function's arguments should be either receiver or `id: Type`.");
+                                    }
+                                },
+                            }
                         }
+                        self.add_structx_definition( join_fields(idents.into_iter()));
+                        return;
                     }
-                    self.add_structx_definition( join_fields( idents.into_iter().zip( types.into_iter().map( Some ))));
-                    return;
                 }
             }
         }
     }
+
+    fn visit_macro( &mut self, mac: &Macro ) {
+        visit::visit_macro( self, mac );
+        self.parse_structx_in_macro(mac);
+    }
 }
 
 impl<'a> StructxCollector<'a> {
-    // parse `structx!{}`/`Structx!{}` in source files.
-    fn parse_structx( &mut self, input: TokenStream ) {
-        let input_pat = wrap_struct_name( "structx_", input );
-
-        if let Ok( pat ) = syn::parse2::<Pat>( input_pat ) {
-            if let Pat::Struct( pat_struct ) = pat {
-                let joined_fields = join_fields(
-                    pat_struct.fields.iter().map( |field| {
-                        if let Member::Named( ident ) = &field.member {
-                            if let Pat::Type( pat_type ) = &*field.pat {
-                                (ident.clone(), Some( (*pat_type.ty).clone() ))
-                            } else {
-                                if let Pat::Macro( PatMacro{ attrs: _, mac }) = &*field.pat {
-                                    if mac.path.leading_colon.is_none() && mac.path.segments.len() == 1 {
-                                        let seg = mac.path.segments.first().unwrap();
-                                        if ( seg.ident == "Structx" || seg.ident == "structx" ) && seg.arguments.is_none() {
-                                            self.parse_structx( mac.tokens.clone().into() );
-                                        }
-                                    }
-                                }
-                                (ident.clone(), None )
-                            }
-                        } else {
-                            panic!("structx!()'s fields should have names.");
-                        }
-                    })
+    /*
+     * Can occur when we use nested structx!() in const generics e.g:
+     * structx! {
+     *  member: MyStruct::<structx!{ name: 0}> { .. }
+     * }
+     */
+    fn parse_structx_in_expr(&mut self, _: &Expr) {
+        // TODO support in the future
+        panic!("nested expressions in structx!() not supported yet!");
+    }
+    fn parse_structx_in_generic_argument(&mut self, arg: &GenericArgument) {
+        match arg {
+            GenericArgument::Type(typ) => self.parse_structx_in_type(typ),
+            GenericArgument::Const(e) => self.parse_structx_in_expr(e),
+            GenericArgument::AssocType(at) => {
+                at.generics.iter().for_each(|gat|
+                    gat.args.iter().for_each(|arg|
+                        self.parse_structx_in_generic_argument(arg)
+                    )
                 );
-                self.add_structx_definition( joined_fields );
-            } else {
-                panic!("structx!()'s supported pattern matching is struct only.");
+                self.parse_structx_in_type(&at.ty);
             }
+            GenericArgument::AssocConst(ac) => {
+                ac.generics.iter().for_each(|gat|
+                    gat.args.iter().for_each(|arg|
+                        self.parse_structx_in_generic_argument(arg)
+                    )
+                );
+                self.parse_structx_in_expr(&ac.value);
+            }
+            GenericArgument::Constraint(_) | GenericArgument::Lifetime(_) => {}
+            _ => {}
+        }
+    }
+    fn parse_structx_in_path_arguments(&mut self, segment: &PathArguments) {
+        match segment {
+            PathArguments::AngleBracketed(generics) => {
+                generics.args.iter().for_each(|arg| self.parse_structx_in_generic_argument(arg));
+            }
+            PathArguments::Parenthesized(args) => {
+                args.inputs.iter().for_each(|arg| self.parse_structx_in_type(arg));
+                self.parse_structx_in_return_type(&args.output);
+            }
+            PathArguments::None => {}
+        }
+    }
+    fn parse_structx_in_path(&mut self, path: &Path) {
+        path.segments.iter().for_each(|seg| self.parse_structx_in_path_arguments(&seg.arguments));
+    }
+    fn parse_structx_in_macro(&mut self, mac: &Macro) {
+        static TYPE_MACRO_STR: &'static str = "Structx";
+        static MACRO_STR: &'static str = "structx";
+        // TODO support full qualified paths to structx: e.g: structx::structx { ... }
+        if mac.path.leading_colon.is_none() && mac.path.segments.len() == 1 {
+            let seg = mac.path.segments.first().unwrap();
+            if ( seg.ident == MACRO_STR || seg.ident == TYPE_MACRO_STR ) && seg.arguments.is_none() {
+                self.parse_structx( mac.tokens.clone().into() );
+            }
+        }
+        // TODO add nested anonymous structs in popular macros such as vec![]
+    }
+    fn parse_structx_in_return_type(&mut self, ret_type: &ReturnType) {
+        match &ret_type {
+            ReturnType::Default => {}
+            ReturnType::Type(_, typ) => self.parse_structx_in_type(&typ),
+        };
+    }
+    fn parse_structx_in_type(&mut self, typ: &Type) {
+        match typ {
+            Type::Array(arr) => self.parse_structx_in_type(&arr.elem),
+            Type::BareFn(f) => {
+                f.inputs.iter().for_each(|arg| self.parse_structx_in_type(&arg.ty));
+                self.parse_structx_in_return_type(&f.output);
+            }
+            Type::Group(g) => self.parse_structx_in_type(&g.elem),
+            Type::Macro(m) => self.parse_structx_in_macro(&m.mac),
+            Type::Paren(p) => self.parse_structx_in_type(&p.elem),
+            Type::Path(p) => {
+                self.parse_structx_in_path(&p.path);
+            }
+            Type::Ptr(p) => self.parse_structx_in_type(&p.elem),
+            Type::Reference(r) => self.parse_structx_in_type(&r.elem),
+            Type::Slice(s) => self.parse_structx_in_type(&s.elem),
+            Type::Tuple(tt) => {
+                tt.elems.iter().for_each(|typ| self.parse_structx_in_type(typ));
+            }
+            // These types represent leaf types which can't contain any more anonymous struct types
+            Type::Infer(_) |
+            Type::Never(_) |
+            Type::ImplTrait(_) |
+            Type::TraitObject(_) |
+            Type::Verbatim(_) => {}
+            _ => panic!("Unknown type {:?} in structx()! ", typ)
+        }
+    }
+    fn parse_structx_in_pat(&mut self, pat: &Pat) {
+        match pat {
+            Pat::Macro(mp) => {
+                self.parse_structx_in_macro(&mp.mac);
+            }
+            Pat::Or(op) => {
+                op.cases.iter().for_each(|pat| {
+                    self.parse_structx_in_pat(&pat);
+                });
+            }
+            Pat::Path(pp) => {
+                self.parse_structx_in_path(&pp.path);
+            }
+            Pat::Range(rp) => {
+                rp.start.iter().for_each(|s| self.parse_structx_in_expr(&s));
+                rp.end.iter().for_each(|e| self.parse_structx_in_expr(&e));
+            }
+            Pat::Reference(rp) => {
+                self.parse_structx_in_pat(&rp.pat);
+            }
+            Pat::Slice(sp) => {
+                sp.elems.iter().for_each(|pat| { self.parse_structx_in_pat(pat); });
+            }
+            Pat::Struct(sp) => {
+                sp.fields.iter().for_each(|pat| {
+                   self.parse_structx_in_pat(&pat.pat);
+                });
+            }
+            Pat::Tuple(tp) => {
+                tp.elems.iter().for_each(|pat| {
+                    self.parse_structx_in_pat(pat);
+                });
+            }
+            Pat::TupleStruct(ts) => {
+                ts.elems.iter().for_each(|pat| {
+                    self.parse_structx_in_pat(pat);
+                });
+                self.parse_structx_in_path(&ts.path);
+            }
+            Pat::Type(pat_type) => {
+                self.parse_structx_in_type(&pat_type.ty);
+            }
+            Pat::Ident(ip) => {
+                ip.subpat.iter().for_each(|(_, pat)| {
+                    self.parse_structx_in_pat(&pat);
+                });
+            }
+            Pat::Rest(_) | Pat::Lit(_) => {},
+            Pat::Verbatim(_) |
+            Pat::Wild(_) | _ => {
+                panic!("Nested pattern {:?} not supported by structx()!", pat);
+            }
+        };
+    }
+    // parse `structx!{}`/`Structx!{}` in source files.
+    fn parse_structx(&mut self, input: TokenStream) {
+        static STRUCT_PREFIX_STR: &'static str = "structx_";
+        let input_pat = wrap_struct_name( STRUCT_PREFIX_STR, input );
+        if let Ok( struct_x ) = syn::parse2::<StructX>( input_pat ) {
+            let joined_fields = join_fields(
+                struct_x.pat.fields.iter().map( |field| {
+                    if let Member::Named( ident ) = &field.member {
+                        self.parse_structx_in_pat(&field.pat);
+                        ident.clone()
+                    } else {
+                        panic!("structx!()'s fields should have names.");
+                    }
+                })
+            );
+            self.add_structx_definition(joined_fields);
         } // Structx!{}'s inner tokens may not be parsed as pattern.
     }
 
-    fn add_structx_definition( &mut self, (struct_name,field_idents,field_types) : (String, Vec<Ident>, Vec<Option<Type>> )) {
-        self.0.entry( struct_name ).or_insert(( field_idents, field_types ));
+    fn add_structx_definition( &mut self, (struct_name, field_idents) : (String, Vec<Ident>)) {
+        self.0.entry( struct_name ).or_insert(field_idents);
     }
 }
 
@@ -164,7 +307,7 @@ fn main() {
 
     let output = struct_map
         .into_iter()
-        .fold( String::new(), |acc, (struct_name, (field_idents, field_types))| {
+        .fold( String::new(), |acc, (struct_name, field_idents)| {
             format!( r#"{}
 #[allow( non_camel_case_types )]
 {lens_traits}
@@ -175,7 +318,7 @@ pub struct {struct_name}<{generics}>{{{fields}
                     acc,
                     lens_traits = lens_traits,
                     struct_name = struct_name,
-                    generics = ( 1..field_types.len() )
+                    generics = (1..field_idents.len())
                         .fold( "T0".to_owned(), |acc, nth| format!( "{},T{}", acc, nth )),
                     fields = field_idents
                         .iter()
@@ -184,5 +327,5 @@ pub struct {struct_name}<{generics}>{{{fields}
             )});
 
     let out_path = PathBuf::from( env::var( "OUT_DIR" ).expect( "$OUT_DIR should exist." ));
-    std::fs::write( out_path.join( "bindings.rs" ), output ).expect( "bindings.rs generated." );
+    fs::write( out_path.join( "bindings.rs" ), output ).expect( "bindings.rs generated." );
 }

--- a/structx_derive/Cargo.toml
+++ b/structx_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "structx_derive"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["oooutlk <oooutlk@outlook.com>"]
 edition = "2021"
 license = "MIT/Apache-2.0"
@@ -17,4 +17,4 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "1.0", features = ["extra-traits","full","visit","visit-mut"] }
+syn = { version = "2.0", features = ["extra-traits","full","visit","visit-mut"] }

--- a/structx_test/Cargo.toml
+++ b/structx_test/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "structx_test"
-version = "0.1.9"
+version = "0.1.10"
 authors = ["oooutlk <oooutlk@outlook.com>"]
 edition = "2021"
 publish = false
 
 [dependencies]
-structx = { path = "../structx", version = "0.1.9" }
+structx = { path = "../structx", version = "0.1.10" }
 lens-rs = { version = "0.3", features = ["structx"], optional = true }
 
 [build-dependencies]

--- a/structx_test/src/lib.rs
+++ b/structx_test/src/lib.rs
@@ -1,5 +1,6 @@
 #[cfg( test )]
 mod tests {
+    use std::collections::HashMap;
     use structx::*;
 
     #[test]
@@ -57,6 +58,67 @@ mod tests {
         }
 
         assert_eq!( returns_recursive_structx(), recursive_structx );
+    }
+
+
+    #[test]
+    fn recursively_nested_anonymous_struct() {
+
+        let model = structx!{
+            // nested macros which contain again structx!() is currently not supported
+            // So you can't use vec![] instead of Vec::from()
+            products: Vec::from([
+                structx! {
+                    id: 0,
+                    name: "Pullover"
+                },
+                structx! {
+                    id: 1,
+                    name: "T-Shirt"
+                },
+            ]),
+            session: structx! {
+                user: structx! {
+                    username: "xxtheusernamexx"
+                },
+                tokens: HashMap::from([("a0bd6d46-3324-4566-836b-96b3767b6295", structx! {
+                    valid_until: 1684249334,
+                    created: 1664249334
+                })])
+            }
+        };
+
+        fn returns_nested_structx(username: &str) -> Structx! {
+            products: Vec<Structx!{ id: usize, name: &'static str }>,
+            session: Structx! {
+                user: Structx! { username: &str },
+                tokens: HashMap<&str, Structx!{ valid_until: usize, created: usize }> }
+        }
+        {
+
+            structx!{
+                products: Vec::from([
+                    structx! {
+                        id: 0,
+                        name: "Pullover"
+                    },
+                    structx! {
+                        id: 1,
+                        name: "T-Shirt"
+                    },
+                ]),
+                session: structx! {
+                    user: structx! {
+                        username
+                    },
+                    tokens: HashMap::from([("a0bd6d46-3324-4566-836b-96b3767b6295", structx! {
+                        valid_until: 1684249334,
+                        created: 1664249334
+                    })])
+                }
+            }
+        }
+        assert_eq!(returns_nested_structx( "xxtheusernamexx"), model);
     }
 
     #[test]


### PR DESCRIPTION
+ Added support for recursive anonymous structs in types
+ Added support for recursive anonymous structs in arbitrary nested patterns
- Removed the types from StructMap for simplification. Types don't need to be stored because for every anonymous struct a fully generic variant gets generated 
- Bumped up the version of syn to 2.0. Therefore added a struct named StructX which implements Parse. Also changed some code to work with syn 2.0. 
- Bumped up the version of structx to 0.1.10, of structx_test to 0.1.10, of structx_derive to 0.1.4 # Changed some intendation and format. Probably we should use rustfmt in the future